### PR TITLE
20200311dev userresearch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,9 +7,11 @@
 *.md
 !README*.md
 README-secret.md
+makefile
 
-/docs/*
+.github/*
+.vscode/*
 /creds/*
+/docs/*
 /store/*
-
 /venv/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV all_ga ga:77768373
 
 ENV PORT 8080
 
-ENV GUNICORN_CMD_ARGS="--timeout 30 --chdir=./src/"
+ENV GUNICORN_CMD_ARGS="--timeout 60 --workers 2 --chdir=./src/"
 
 #WORKDIR /cj-data/src
 


### PR DESCRIPTION
Fixes Worker timeout expended to 60 seconds and add an additional worker

## Proposed Changes

  - explicitly set worker timeout to 60 seconds
  - add an additional worker
  - clean up dockerignore file to improve readability